### PR TITLE
Fix installer

### DIFF
--- a/gimp-plugins/installGimpML.sh
+++ b/gimp-plugins/installGimpML.sh
@@ -9,13 +9,13 @@ if [ ! -d "gimpenv" ]; then
 		       
 		elif [[ $(lsb_release -rs) == "20.04" ]]; then #for ubuntu 20.04
 			sudo apt install python2-minimal
-			wget https://bootstrap.pypa.io/get-pip.py 
+			wget https://bootstrap.pypa.io/pip/2.7/get-pip.py --output-document get-pip.py 
 			alias python='python2'
 			python get-pip.py	
 			sudo apt-get install libpython2.7
 
 		elif [[ $(lsb_release -rs) == "10" ]]; then #for debian 10
-			wget https://bootstrap.pypa.io/get-pip.py 
+			wget https://bootstrap.pypa.io/pip/2.7/get-pip.py --output-document get-pip.py
 			python get-pip.py
 		fi
 	fi


### PR DESCRIPTION
Changes in https://bootstrap.pypa.io/get-pip.py script made the installer unusable.

```
this_python = sys.version_info[:2]
min_version = (3, 6)
if this_python < min_version:
    message_parts = [
        "This script does not work on Python {}.{}".format(*this_python),
        "The minimum supported Python version is {}.{}.".format(*min_version),
        "Please use https://bootstrap.pypa.io/pip/{}.{}/get-pip.py instead.".format(*this_python),
    ]
    print("ERROR: " + " ".join(message_parts))
    sys.exit(1)
```