### PR TITLE
more portability for x86_64 environment

### DIFF
--- a/gimp-plugins/colorpalette.py
+++ b/gimp-plugins/colorpalette.py
@@ -2,8 +2,10 @@ import os
 baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
 
 import cv2
 import numpy as np

--- a/gimp-plugins/deblur.py
+++ b/gimp-plugins/deblur.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'DeblurGANv2'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'DeblurGANv2'])
 
 import cv2
 from predictorClass import Predictor

--- a/gimp-plugins/deepcolor.py
+++ b/gimp-plugins/deepcolor.py
@@ -2,7 +2,11 @@ import os
 baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 from gimpfu import *
 import sys
-sys.path.extend([baseLoc+'gimpenv/lib/python2.7',baseLoc+'gimpenv/lib/python2.7/site-packages',baseLoc+'gimpenv/lib/python2.7/site-packages/setuptools',baseLoc+'ideepcolor'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc+'ideepcolor'])
 import numpy as np
 import torch
 import cv2

--- a/gimp-plugins/deepdehaze.py
+++ b/gimp-plugins/deepdehaze.py
@@ -5,9 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'PyTorch-Image-Dehazing'])
-
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'PyTorch-Image-Dehazing'])
 
 import torch
 import net

--- a/gimp-plugins/deepdenoise.py
+++ b/gimp-plugins/deepdenoise.py
@@ -5,9 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'PD-Denoising-pytorch'])
-
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'PD-Denoising-pytorch'])
 
 from denoiser import *
 from argparse import Namespace

--- a/gimp-plugins/deepmatting.py
+++ b/gimp-plugins/deepmatting.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'pytorch-deep-image-matting'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'pytorch-deep-image-matting'])
 
 import torch
 from argparse import Namespace

--- a/gimp-plugins/enlighten.py
+++ b/gimp-plugins/enlighten.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'EnlightenGAN'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'EnlightenGAN'])
 
 from argparse import Namespace
 import cv2

--- a/gimp-plugins/facegen.py
+++ b/gimp-plugins/facegen.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc+'gimpenv/lib/python2.7',baseLoc+'gimpenv/lib/python2.7/site-packages',baseLoc+'gimpenv/lib/python2.7/site-packages/setuptools',baseLoc+'CelebAMask-HQ/MaskGAN_demo'])
-
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc+'CelebAMask-HQ/MaskGAN_demo'])
 
 import torch
 from argparse import Namespace

--- a/gimp-plugins/faceparse.py
+++ b/gimp-plugins/faceparse.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'face-parsing-PyTorch'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'face-parsing-PyTorch'])
 
 from model import BiSeNet
 from PIL import Image

--- a/gimp-plugins/inpainting.py
+++ b/gimp-plugins/inpainting.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc+'gimpenv/lib/python2.7',baseLoc+'gimpenv/lib/python2.7/site-packages',baseLoc+'gimpenv/lib/python2.7/site-packages/setuptools',baseLoc+'Inpainting'])
-
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc+'Inpainting'])
 
 import torch
 import numpy as np

--- a/gimp-plugins/interpolateframes.py
+++ b/gimp-plugins/interpolateframes.py
@@ -5,8 +5,11 @@ savePath = '/'.join(baseLoc.split('/')[:-2]) + '/output/interpolateframes'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'RIFE'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'RIFE'])
 
 import cv2
 import torch

--- a/gimp-plugins/kmeans.py
+++ b/gimp-plugins/kmeans.py
@@ -5,7 +5,10 @@ baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc+'gimpenv/lib/python2.7',baseLoc+'gimpenv/lib/python2.7/site-packages',baseLoc+'gimpenv/lib/python2.7/site-packages/setuptools'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
 
 import numpy as np
 from scipy.cluster.vq import kmeans2

--- a/gimp-plugins/monodepth.py
+++ b/gimp-plugins/monodepth.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'MiDaS'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'MiDaS'])
 
 from run import run_depth
 from monodepth_net import MonoDepthNet

--- a/gimp-plugins/semseg.py
+++ b/gimp-plugins/semseg.py
@@ -4,8 +4,10 @@ baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 
 from gimpfu import *
 import sys
-sys.path.extend([baseLoc+'gimpenv/lib/python2.7',baseLoc+'gimpenv/lib/python2.7/site-packages',baseLoc+'gimpenv/lib/python2.7/site-packages/setuptools'])
-
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
 
 from PIL import Image
 import torch

--- a/gimp-plugins/super_resolution.py
+++ b/gimp-plugins/super_resolution.py
@@ -5,8 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__)) + '/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc + 'gimpenv/lib/python2.7', baseLoc + 'gimpenv/lib/python2.7/site-packages',
-                 baseLoc + 'gimpenv/lib/python2.7/site-packages/setuptools', baseLoc + 'pytorch-SRResNet'])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc + 'pytorch-SRResNet'])
 
 from argparse import Namespace
 import torch

--- a/gimp-plugins/syncWeights.py
+++ b/gimp-plugins/syncWeights.py
@@ -1,6 +1,11 @@
-import requests
 import os
+baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 from gimpfu import *
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+import requests
 
 def download_file_from_google_drive(id, destination,fileSize):
 	URL = "https://docs.google.com/uc?export=download"

--- a/gimp-plugins/update.py
+++ b/gimp-plugins/update.py
@@ -5,7 +5,11 @@ baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
 from gimpfu import *
 import sys
 
-sys.path.extend([baseLoc+'gimpenv/lib/python2.7',baseLoc+'gimpenv/lib/python2.7/site-packages',baseLoc+'gimpenv/lib/python2.7/site-packages/setuptools',baseLoc])
+activate_this = os.path.join(baseLoc, 'gimpenv', 'bin', 'activate_this.py')
+with open(activate_this) as f:
+    code = compile(f.read(), activate_this, 'exec')
+    exec(code, dict(__file__=activate_this))
+sys.path.extend([baseLoc])
 
 import shutil
 import syncWeights 


### PR DESCRIPTION
Hi,
There are errors when GIMP try load the plugins on x86_64 Linux (CentOS 7.4, x86_64).
The changes try to make these *.py work on x86_64 environment.

Please help to review, thanks.
